### PR TITLE
Add static RWA marketplace starter

### DIFF
--- a/RWAPlatformMVP.md
+++ b/RWAPlatformMVP.md
@@ -1,0 +1,116 @@
+# Real-World Asset (RWA) Marketplace MVP Plan
+
+## 1. Objective
+Launch a lightweight marketplace that helps asset originators list real-world assets (e.g., invoices, rentals, equipment leases) and lets investors review deals and reserve allocations without handling custody, KYC, or payments inside the app.
+
+## 2. Core Outcomes
+- Publish compliant deal pages with standardized metrics, docs, and risk flags.
+- Allow investors to join a waitlist, request allocations, and receive email follow-ups.
+- Provide an intake form for asset originators to submit deals for review.
+- Operate on zero/low cost using static hosting + third-party embeds (forms, analytics, scheduling).
+
+## 3. MVP Features
+1. **Landing Page**
+   - Value proposition, short explainer of how allocations work, and call-to-actions (CTA) for investors and originators.
+   - Credibility signals: featured assets, partner logos (optional), basic FAQ.
+2. **Deal Directory**
+   - Card grid of active/past deals with filters for sector, geography, yield range, and tenor.
+   - Clicking a card opens a deal detail page (Markdown/MDX) with metrics table, docs links, risk notes, and CTA to "Request Allocation".
+3. **Deal Detail Template**
+   - Hero with summary stats (target APY, advance rate, LTV, minimum ticket, duration, repayment frequency).
+   - Sections for: asset overview, structure, covenants, collateral, servicing/backup servicer, key risks, reporting cadence, FAQ.
+   - Download links for teaser/PDD/P&L and a short Loom video.
+   - Embeds: Calendly for diligence calls; Typeform/Tally for allocation requests (captures email, entity type, amount, jurisdiction, accreditation self-attest).
+4. **Originator Intake**
+   - Form embed to collect company info, track record, asset type, servicing model, expected APY, legal docs, and references.
+   - Autoresponder email with next steps and data room checklist.
+5. **Email & CRM**
+   - Mailing list capture on every page via MailerLite (free tier) or ConvertKit free plan.
+   - Allocation and intake forms push to Airtable base (free) via native connectors or Make (free tier) scenario.
+6. **Analytics & Trust**
+   - Privacy-friendly analytics (Plausible/Umami free self-hosted) or Google Analytics.
+   - Public status page for upcoming drops and recent updates (changelog style).
+
+## 4. Zero/Low-Cost Architecture
+```
+Static Frontend (Next.js or Astro on Vercel/Netlify free tier)
+    │
+    ├── Content: Markdown/MDX for deals + config-driven directory
+    ├── Styling: Tailwind + free component kit (e.g., DaisyUI)
+    ├── Forms: Typeform/Tally embeds, Netlify Forms fallback
+    ├── Scheduling: Calendly embed for investor calls
+    └── Email/CRM: MailerLite signup + Airtable/Make for lead sync
+
+Data & Ops
+    ├── Airtable base: Leads, Allocation Requests, Originator Intakes
+    ├── Make (Integromat) free tier: form → Airtable → email notifications
+    └── Analytics: Plausible/GA tag
+```
+
+## 5. User Flows
+- **Investor**: Landing → Deal directory → Deal page → Request Allocation (form) → receives confirmation + Calendly link.
+- **Originator**: Landing → Submit Deal form → auto email with checklist → team review in Airtable → follow-up via Calendly.
+- **Admin**: Update deal Markdown, publish via Git, review leads in Airtable, send updates via MailerLite.
+
+## 6. Delivery Checklist (Week 1-2)
+- [ ] Pick framework (Astro for static speed) and set up repo + free hosting.
+- [ ] Create layout + theme (hero, grid cards, footer, FAQ, CTA blocks).
+- [ ] Build deal directory from JSON/YAML config → generates card grid + detail pages.
+- [ ] Configure Typeform/Tally for Allocation Request and Originator Intake; connect to Airtable.
+- [ ] Add MailerLite embed + double opt-in copy.
+- [ ] Add Calendly embed on deal pages and contact page.
+- [ ] Write 2-3 sample deals with mock data and risk notes.
+- [ ] Add legal/disclaimer pages (not investment advice, accreditation self-attest, data usage, cookies/analytics note).
+- [ ] Set up analytics tag and test events.
+- [ ] Document how to view site locally and deploy (README snippet below).
+
+## 7. Content Structure Proposal
+```
+content/
+  deals/
+    2024-bridge-loan.md
+    2024-invoice-finance.md
+  pages/
+    landing.md (hero copy, CTA targets)
+    faq.md
+    trust.md (process, partners, safeguards)
+    updates.md (changelog)
+site.config.json (site title, nav, social, form links, mailer id)
+```
+
+### Deal Frontmatter Fields
+- `title`, `slug`, `status` (live, upcoming, closed)
+- `sector`, `geography`, `asset_type`
+- `target_apy`, `ltv`, `advance_rate`, `tenor_months`, `min_ticket`
+- `structure` (seniority, SPV/series note, waterfall summary)
+- `collateral` (type, custodian, backup servicer)
+- `risk_flags` (array with label + description)
+- `docs` (links to teaser, PDD, financials)
+- `call_to_action_url` (Typeform/Tally link)
+- `calendly_url`
+- `last_updated`
+
+## 8. Local Preview & Deployment
+1. Install Node 18+ and PNPM (recommended) or npm.
+2. Clone repo → `cd rwa-marketplace` → `pnpm install` → `pnpm dev` (or `npm install && npm run dev`).
+3. Environment vars (if needed) stored in `.env.local` for form keys/analytics IDs.
+4. Deploy by connecting GitHub repo to Vercel/Netlify and keeping default build (`pnpm build` / `npm run build`) and output (`dist` for Astro, `.next` for Next.js`).
+5. Share preview URLs from the hosting dashboard with stakeholders.
+
+## 9. Next Iterations (Post-MVP)
+- Investor login for saved deals/watchlists; gated data room links.
+- Basic compliance guardrails: block unsupported jurisdictions, accreditation checkboxes, and digital acknowledgement of disclaimers.
+- Automated email sequences (MailerLite) triggered from Airtable status changes.
+- Metrics dashboard (Metabase) pulling from Airtable exports.
+- Payment rails and settlement (Stripe Treasury/Anchorage) once legal/compliance ready.
+
+## 10. Risks & Mitigations
+- **Regulatory**: Keep site informational; require self-attestation and disclaimers; avoid soliciting investments directly.
+- **Data accuracy**: Standardize deal templates; require originators to upload source docs; periodic updates noted on deal pages.
+- **Ops load**: Automate notifications with Make; use templates for new deals; calendar slots reserved weekly for diligence calls.
+- **Trust**: Publish methodology, prior case studies, and independent references when available.
+
+## 11. Static MVP Starter (included in repo)
+- **Location**: `rwa-mvp/` contains a static HTML/CSS/JS starter that mirrors the MVP layout (hero, filters, deal grid, modal, intake embed, disclaimers) with sample data in `assets/data.js`.
+- **Mac quickstart**: From the repo root run `cd rwa-mvp && python3 -m http.server 5500`, then open `http://localhost:5500/index.html`.
+- **How to customize**: Replace placeholder Typeform/Tally + Calendly URLs, edit `assets/data.js` to add deals (sector, geography, APY/LTV/tenor, docs, risks), and drop analytics tags into `assets/snippets.html`.

--- a/rwa-mvp/README.md
+++ b/rwa-mvp/README.md
@@ -1,0 +1,28 @@
+# RWA Marketplace MVP Starter
+
+A static, zero-cost-friendly landing for real-world asset deals. Uses plain HTML/CSS/JS so you can run it locally on macOS without extra tooling. Replace the placeholder form + Calendly links with your own.
+
+## Quickstart (macOS)
+1. Ensure Python 3 is installed (bundled on macOS). In Terminal, from this folder run:
+   ```bash
+   python3 -m http.server 5500
+   ```
+2. Open `http://localhost:5500/index.html` in your browser.
+3. Edit `assets/data.js` to add/edit deals. Text and styling live in `index.html` and `assets/styles.css`.
+
+## Customize
+- **Forms**: Swap the Tally/Typeform iframe URLs in `index.html` and the `callToActionUrl` fields in `assets/data.js`.
+- **Calendly**: Update `calendlyUrl` per deal in `assets/data.js`.
+- **Analytics**: Add your Plausible or Google Analytics tag to `assets/snippets.html` then include it in `index.html` (already referenced for you).
+- **Branding**: Change the `Atlas Yield` brand text and colors in `assets/styles.css`.
+
+## Deployment
+- Drop the folder onto Netlify/Vercel as a static site, or serve from any S3/Cloudflare Pages bucket. No build step required.
+- If you later move to Astro/Next.js, you can import the JSON-like `deals` array and re-use the markup as components.
+
+## Files
+- `index.html` – layout with hero, filters, deal grid, modal, intake form, and disclaimers.
+- `assets/data.js` – sample deals + fields (sector, geography, APY, LTV, tenor, docs, risks, CTA links).
+- `assets/scripts.js` – filter logic, modal rendering, and live KPI averages.
+- `assets/styles.css` – gradients, grid layout, buttons, and modal styling.
+- `assets/snippets.html` – drop-in slot for analytics tags or additional embeds.

--- a/rwa-mvp/assets/data.js
+++ b/rwa-mvp/assets/data.js
@@ -1,0 +1,77 @@
+const deals = [
+  {
+    title: "US Freight Factoring",
+    slug: "us-freight-factoring",
+    sector: "Logistics",
+    geography: "United States",
+    targetApy: 11.5,
+    ltv: 65,
+    tenorMonths: 6,
+    minTicket: "$10k",
+    status: "live",
+    summary: "Advancing against verified freight invoices with recourse to fleet operators.",
+    structure: "Senior secured, 85% advance rate, weekly remits held in segregated accounts.",
+    collateral: "Pledged receivables + UCC filings; backup servicer in place.",
+    docs: [
+      { label: "Teaser", url: "https://example.com/teaser.pdf" },
+      { label: "Data room", url: "https://example.com/data-room" }
+    ],
+    riskFlags: [
+      "Customer concentration in top 5 brokers.",
+      "Short performance history for 2 of 12 fleet partners."
+    ],
+    callToActionUrl: "https://tally.so/r/3NpDMZ",
+    calendlyUrl: "https://calendly.com",
+    lastUpdated: "2024-06-01"
+  },
+  {
+    title: "UK B2B SaaS Receivables",
+    slug: "uk-saas-receivables",
+    sector: "Software",
+    geography: "United Kingdom",
+    targetApy: 9.4,
+    ltv: 60,
+    tenorMonths: 9,
+    minTicket: "$5k",
+    status: "live",
+    summary: "Advances against contracted MRR with 12-month retention history.",
+    structure: "Series note, senior claims on ARR with 1.35x coverage covenant.",
+    collateral: "Assigned receivables, de-risked by churn guardrail and escrow.",
+    docs: [
+      { label: "One pager", url: "https://example.com/saas.pdf" },
+      { label: "FAQ", url: "https://example.com/faq" }
+    ],
+    riskFlags: [
+      "Macroeconomic sensitivity to SMB spending.",
+      "Requires monthly MRR reporting to maintain advance rate."
+    ],
+    callToActionUrl: "https://tally.so/r/3NpDMZ",
+    calendlyUrl: "https://calendly.com",
+    lastUpdated: "2024-06-10"
+  },
+  {
+    title: "Spain Short-Term Rentals",
+    slug: "spain-str",
+    sector: "Real Estate",
+    geography: "Spain",
+    targetApy: 12.1,
+    ltv: 72,
+    tenorMonths: 12,
+    minTicket: "$25k",
+    status: "upcoming",
+    summary: "Bridge notes on stabilized STR units with 1.5x DSCR and seasonal reserves.",
+    structure: "Senior loan with cash sweep, 70% LTC cap, quarterly distributions.",
+    collateral: "Property liens + deposit account control; backup servicer engaged.",
+    docs: [
+      { label: "Model", url: "https://example.com/model" },
+      { label: "Video walkthrough", url: "https://example.com/video" }
+    ],
+    riskFlags: [
+      "Seasonality in ADR/occupancy requires reserve coverage.",
+      "Regulatory changes in select municipalities."
+    ],
+    callToActionUrl: "https://tally.so/r/3NpDMZ",
+    calendlyUrl: "https://calendly.com",
+    lastUpdated: "2024-06-15"
+  }
+];

--- a/rwa-mvp/assets/scripts.js
+++ b/rwa-mvp/assets/scripts.js
@@ -1,0 +1,166 @@
+const sectorFilter = document.querySelector('#filter-sector');
+const geoFilter = document.querySelector('#filter-geo');
+const apyFilter = document.querySelector('#filter-apy');
+const apyValue = document.querySelector('#filter-apy-value');
+const grid = document.querySelector('#deal-grid');
+const modal = document.querySelector('#deal-modal');
+const modalContent = document.querySelector('#modal-content');
+const statApy = document.querySelector('#stat-apy');
+const statLtv = document.querySelector('#stat-ltv');
+const statTenor = document.querySelector('#stat-tenor');
+const snippetsPath = 'assets/snippets.html';
+
+const unique = (items, key) => Array.from(new Set(items.map((i) => i[key])));
+
+function populateFilters() {
+  unique(deals, 'sector').forEach((sector) => {
+    const option = document.createElement('option');
+    option.value = sector;
+    option.textContent = sector;
+    sectorFilter.appendChild(option);
+  });
+
+  unique(deals, 'geography').forEach((geo) => {
+    const option = document.createElement('option');
+    option.value = geo;
+    option.textContent = geo;
+    geoFilter.appendChild(option);
+  });
+}
+
+function filteredDeals() {
+  const minApy = Number(apyFilter.value);
+  return deals.filter((deal) => {
+    const sectorMatches = sectorFilter.value === 'all' || deal.sector === sectorFilter.value;
+    const geoMatches = geoFilter.value === 'all' || deal.geography === geoFilter.value;
+    const apyMatches = deal.targetApy >= minApy;
+    return sectorMatches && geoMatches && apyMatches;
+  });
+}
+
+function renderStats(items) {
+  if (!items.length) return;
+  const avgApy = items.reduce((sum, d) => sum + d.targetApy, 0) / items.length;
+  const avgLtv = items.reduce((sum, d) => sum + d.ltv, 0) / items.length;
+  const avgTenor = items.reduce((sum, d) => sum + d.tenorMonths, 0) / items.length;
+
+  statApy.textContent = `${avgApy.toFixed(1)}%`;
+  statLtv.textContent = `${avgLtv.toFixed(0)}%`;
+  statTenor.textContent = `${avgTenor.toFixed(1)} mo`;
+}
+
+function renderDeals() {
+  const items = filteredDeals();
+  grid.innerHTML = '';
+
+  if (!items.length) {
+    grid.innerHTML = '<p class="muted">No deals match this filter. Try lowering the APY or clearing filters.</p>';
+    return;
+  }
+
+  items.forEach((deal) => {
+    const card = document.createElement('article');
+    card.className = 'deal-card';
+    card.innerHTML = `
+      <div class="pill ${deal.status}">${deal.status}</div>
+      <h3>${deal.title}</h3>
+      <p class="muted">${deal.summary}</p>
+      <dl class="metrics">
+        <div><dt>Target APY</dt><dd>${deal.targetApy}%</dd></div>
+        <div><dt>LTV</dt><dd>${deal.ltv}%</dd></div>
+        <div><dt>Tenor</dt><dd>${deal.tenorMonths} mo</dd></div>
+        <div><dt>Min ticket</dt><dd>${deal.minTicket}</dd></div>
+      </dl>
+      <div class="tags">
+        <span>${deal.sector}</span>
+        <span>${deal.geography}</span>
+      </div>
+      <button class="button ghost" data-slug="${deal.slug}">View details</button>
+    `;
+    card.querySelector('button').addEventListener('click', () => openDeal(deal.slug));
+    grid.appendChild(card);
+  });
+
+  renderStats(items);
+}
+
+function openDeal(slug) {
+  const deal = deals.find((d) => d.slug === slug);
+  if (!deal) return;
+
+  modalContent.innerHTML = `
+    <div class="pill ${deal.status}">${deal.status}</div>
+    <h2>${deal.title}</h2>
+    <p>${deal.summary}</p>
+    <dl class="metrics">
+      <div><dt>Target APY</dt><dd>${deal.targetApy}%</dd></div>
+      <div><dt>LTV</dt><dd>${deal.ltv}%</dd></div>
+      <div><dt>Tenor</dt><dd>${deal.tenorMonths} months</dd></div>
+      <div><dt>Minimum ticket</dt><dd>${deal.minTicket}</dd></div>
+    </dl>
+    <h3>Structure</h3>
+    <p>${deal.structure}</p>
+    <h3>Collateral</h3>
+    <p>${deal.collateral}</p>
+    <h3>Docs & media</h3>
+    <ul class="links">
+      ${deal.docs.map((doc) => `<li><a href="${doc.url}" target="_blank" rel="noreferrer">${doc.label}</a></li>`).join('')}
+    </ul>
+    <h3>Key risks</h3>
+    <ul class="risks">
+      ${deal.riskFlags.map((risk) => `<li>${risk}</li>`).join('')}
+    </ul>
+    <div class="modal-actions">
+      <a class="button primary" href="${deal.callToActionUrl}" target="_blank" rel="noreferrer">Request allocation</a>
+      <a class="button ghost" href="${deal.calendlyUrl}" target="_blank" rel="noreferrer">Book diligence call</a>
+    </div>
+    <p class="muted">Last updated: ${deal.lastUpdated}</p>
+  `;
+
+  modal.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('no-scroll');
+}
+
+function closeModal() {
+  modal.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('no-scroll');
+}
+
+function attachListeners() {
+  [sectorFilter, geoFilter, apyFilter].forEach((input) => {
+    input.addEventListener('input', () => {
+      if (input === apyFilter) {
+        apyValue.textContent = `${apyFilter.value}%+`;
+      }
+      renderDeals();
+    });
+  });
+
+  modal.addEventListener('click', (event) => {
+    if (event.target.dataset.close !== undefined || event.target === modal) {
+      closeModal();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') closeModal();
+  });
+}
+
+function loadSnippets() {
+  fetch(snippetsPath)
+    .then((response) => response.text())
+    .then((html) => {
+      const template = document.createElement('template');
+      template.innerHTML = html.trim();
+      document.head.append(...template.content.childNodes);
+    })
+    .catch(() => {
+      console.info('Optional analytics snippet not loaded.');
+    });
+}
+
+populateFilters();
+attachListeners();
+renderDeals();
+loadSnippets();

--- a/rwa-mvp/assets/snippets.html
+++ b/rwa-mvp/assets/snippets.html
@@ -1,0 +1,2 @@
+<!-- Paste analytics tags (e.g., Plausible or Google Analytics) here. Example: -->
+<!-- <script defer data-domain="yourdomain.com" src="https://plausible.io/js/script.js"></script> -->

--- a/rwa-mvp/assets/styles.css
+++ b/rwa-mvp/assets/styles.css
@@ -1,0 +1,126 @@
+:root {
+  --bg: #0b1021;
+  --card: #0f172a;
+  --muted: #94a3b8;
+  --accent: #8b5cf6;
+  --accent-2: #22d3ee;
+  --border: #1f2937;
+  --text: #e5e7eb;
+  --shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(139, 92, 246, 0.08), transparent 25%),
+    radial-gradient(circle at 80% 10%, rgba(34, 211, 238, 0.08), transparent 20%),
+    var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+.no-scroll { overflow: hidden; }
+
+a { color: #cbd5ff; text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+  padding: 24px 0;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(8px);
+  background: rgba(11, 16, 33, 0.9);
+  border-bottom: 1px solid var(--border);
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.brand { display: flex; align-items: center; gap: 10px; font-weight: 700; letter-spacing: 0.3px; }
+.brand .dot { width: 12px; height: 12px; border-radius: 50%; background: linear-gradient(135deg, var(--accent), var(--accent-2)); box-shadow: 0 0 12px rgba(139, 92, 246, 0.6); }
+.brand-name { font-size: 18px; }
+
+.nav { display: flex; gap: 14px; align-items: center; }
+.nav a { color: var(--text); font-weight: 600; padding: 8px 10px; border-radius: 8px; }
+.nav a.primary { background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #0b1021; box-shadow: var(--shadow); }
+.nav a:hover { background: #111827; }
+
+.hero { padding: 64px 0 32px; }
+.hero-content { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 32px; align-items: center; }
+.eyebrow { text-transform: uppercase; letter-spacing: 1px; color: var(--muted); font-size: 12px; margin-bottom: 8px; }
+.lede { color: #d1d5db; }
+.actions { display: flex; gap: 12px; margin: 20px 0 8px; }
+.badges { display: flex; flex-wrap: wrap; gap: 10px; color: #cbd5e1; font-size: 14px; }
+.badges span { background: rgba(255, 255, 255, 0.06); padding: 8px 12px; border-radius: 999px; border: 1px solid var(--border); }
+
+.button { display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 12px 16px; border-radius: 10px; border: 1px solid transparent; font-weight: 700; cursor: pointer; transition: transform 0.1s ease, box-shadow 0.2s ease; }
+.button.primary { background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #0b1021; box-shadow: var(--shadow); }
+.button.ghost { background: transparent; color: var(--text); border-color: var(--border); }
+.button:hover { transform: translateY(-1px); }
+
+.stat-card { background: linear-gradient(180deg, rgba(139, 92, 246, 0.2), rgba(15, 23, 42, 0.9)); border: 1px solid var(--border); border-radius: 16px; padding: 20px; box-shadow: var(--shadow); }
+.stat-card .label { color: var(--muted); margin: 0 0 10px; font-size: 14px; }
+.stat { display: flex; align-items: baseline; gap: 12px; margin: 6px 0; }
+.stat-value { font-size: 26px; font-weight: 700; }
+.stat-label { color: var(--muted); }
+.footnote { color: var(--muted); font-size: 13px; margin-top: 10px; }
+
+.band { background: #0a0f1d; border-block: 1px solid var(--border); }
+.band-content { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 26px; align-items: center; }
+.card { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; box-shadow: var(--shadow); }
+.steps { color: #d1d5db; }
+.steps li + li { margin-top: 10px; }
+
+.deals { padding: 56px 0; }
+.section-header { display: flex; justify-content: space-between; gap: 16px; align-items: flex-end; flex-wrap: wrap; }
+.filters { display: flex; gap: 14px; flex-wrap: wrap; }
+.filters label { display: grid; color: var(--muted); font-size: 14px; gap: 6px; }
+select, input[type="range"] { background: var(--card); color: var(--text); border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; }
+.range-value { color: #d1d5db; font-weight: 700; }
+
+.deal-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; margin-top: 20px; }
+.deal-card { padding: 18px; background: var(--card); border-radius: 14px; border: 1px solid var(--border); box-shadow: var(--shadow); display: grid; gap: 10px; }
+.metrics { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px 12px; }
+.metrics dt { color: var(--muted); font-size: 13px; }
+.metrics dd { margin: 0; font-weight: 700; }
+.tags { display: flex; gap: 8px; flex-wrap: wrap; }
+.tags span { background: rgba(255, 255, 255, 0.05); border: 1px solid var(--border); padding: 6px 10px; border-radius: 999px; font-size: 13px; }
+.pill { display: inline-flex; align-items: center; padding: 6px 10px; border-radius: 999px; font-weight: 700; text-transform: uppercase; font-size: 12px; letter-spacing: 0.5px; border: 1px solid var(--border); }
+.pill.live { color: #10b981; border-color: rgba(16, 185, 129, 0.3); }
+.pill.upcoming { color: #f59e0b; border-color: rgba(245, 158, 11, 0.3); }
+
+.split { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; align-items: start; }
+.checks { list-style: none; padding: 0; margin: 0; color: #d1d5db; }
+.checks li { position: relative; padding-left: 20px; margin: 8px 0; }
+.checks li::before { content: '✓'; position: absolute; left: 0; color: var(--accent-2); }
+
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
+.muted { color: var(--muted); }
+
+.embed iframe { width: 100%; border: none; min-height: 320px; background: #fff; border-radius: 10px; }
+
+.modal { position: fixed; inset: 0; display: grid; place-items: center; background: rgba(0, 0, 0, 0.55); opacity: 0; pointer-events: none; transition: opacity 0.2s ease; }
+.modal[aria-hidden="false"] { opacity: 1; pointer-events: auto; }
+.modal-card { background: #0b1225; border-radius: 16px; padding: 24px; width: min(780px, 92vw); max-height: 88vh; overflow: auto; border: 1px solid var(--border); box-shadow: var(--shadow); position: relative; }
+.close { position: absolute; right: 12px; top: 12px; background: transparent; border: 1px solid var(--border); color: var(--text); border-radius: 50%; width: 32px; height: 32px; font-size: 18px; cursor: pointer; }
+.links, .risks { padding-left: 18px; color: #d1d5db; }
+.modal-actions { display: flex; gap: 10px; margin: 14px 0; flex-wrap: wrap; }
+
+@media (max-width: 840px) {
+  .hero-content, .band-content { grid-template-columns: 1fr; }
+  .hero { padding-top: 32px; }
+  .nav { display: none; }
+}

--- a/rwa-mvp/index.html
+++ b/rwa-mvp/index.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>RWA Marketplace MVP</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-content">
+      <div class="brand">
+        <span class="dot"></span>
+        <span class="brand-name">Atlas Yield</span>
+      </div>
+      <nav class="nav">
+        <a href="#deals">Deals</a>
+        <a href="#about">How it works</a>
+        <a href="#intake">Submit a deal</a>
+        <a class="primary" href="#waitlist">Join waitlist</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero" id="waitlist">
+      <div class="container hero-content">
+        <div>
+          <p class="eyebrow">Real-World Asset marketplace</p>
+          <h1>Reserve allocations in vetted private credit deals.</h1>
+          <p class="lede">Standardized metrics, fast diligence, and a clear path to allocation requests without handling payments or custody in-app.</p>
+          <div class="actions">
+            <a class="button primary" href="https://tally.so/r/3NpDMZ" target="_blank" rel="noreferrer">Request allocation</a>
+            <a class="button ghost" href="#deals">Browse deals</a>
+          </div>
+          <div class="badges">
+            <span>Self-attested accredited only</span>
+            <span>Zero-fee reservations</span>
+            <span>Weekly drops</span>
+          </div>
+        </div>
+        <div class="stat-card">
+          <p class="label">Live metrics</p>
+          <div class="stat">
+            <span class="stat-value" id="stat-apy">10.2%</span>
+            <span class="stat-label">Avg target APY</span>
+          </div>
+          <div class="stat">
+            <span class="stat-value" id="stat-ltv">68%</span>
+            <span class="stat-label">Weighted LTV</span>
+          </div>
+          <div class="stat">
+            <span class="stat-value" id="stat-tenor">8.5 mo</span>
+            <span class="stat-label">Avg tenor</span>
+          </div>
+          <p class="footnote">Metrics update when you filter deals.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="band" id="about">
+      <div class="container band-content">
+        <div>
+          <p class="eyebrow">How it works</p>
+          <h2>Standardized deal pages with frictionless calls to action.</h2>
+          <ul class="checks">
+            <li>Request allocations via Typeform/Tally embeds; we confirm via email.</li>
+            <li>Schedule diligence calls directly on each deal page (Calendly).</li>
+            <li>Originators submit via intake form; we sync to Airtable for review.</li>
+            <li>Disclaimers + self-attestation to keep the experience informational.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>What we ship this week</h3>
+          <ol class="steps">
+            <li>Static site (Astro/Next ready) deployable on Vercel/Netlify.</li>
+            <li>Config-driven deal directory and detail modal.</li>
+            <li>Forms wired to Typeform/Tally; email capture via MailerLite.</li>
+            <li>Analytics ready: drop your Plausible/GA tag in <code>assets/snippets.html</code>.</li>
+          </ol>
+        </div>
+      </div>
+    </section>
+
+    <section class="container deals" id="deals">
+      <div class="section-header">
+        <div>
+          <p class="eyebrow">Open allocations</p>
+          <h2>Live deals</h2>
+        </div>
+        <div class="filters">
+          <label>
+            Sector
+            <select id="filter-sector">
+              <option value="all">All</option>
+            </select>
+          </label>
+          <label>
+            Geography
+            <select id="filter-geo">
+              <option value="all">All</option>
+            </select>
+          </label>
+          <label>
+            Min target APY
+            <input type="range" id="filter-apy" min="6" max="20" value="8" />
+            <span class="range-value" id="filter-apy-value">8%+</span>
+          </label>
+        </div>
+      </div>
+
+      <div id="deal-grid" class="deal-grid"></div>
+      <p class="muted">Click a card to view structure, docs, and risk notes.</p>
+    </section>
+
+    <section class="container" id="intake">
+      <div class="split">
+        <div>
+          <p class="eyebrow">Originator intake</p>
+          <h2>Submit your deal for the next drop.</h2>
+          <p>We review track record, servicing, collateral, and jurisdictional fit. Expect a response within 3 business days.</p>
+          <ul class="checks">
+            <li>Asset types: invoices, revenue share, short-term rentals, equipment leases.</li>
+            <li>Provide proof of collections, servicing waterfall, and key covenants.</li>
+            <li>We currently avoid consumer loans and unsecured mezzanine risk.</li>
+          </ul>
+        </div>
+        <div class="card embed">
+          <h3>Intake form</h3>
+          <iframe src="https://tally.so/r/mJ7P23" title="Originator intake" loading="lazy"></iframe>
+          <p class="muted">Replace the iframe URL with your Typeform/Tally link.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="container" id="trust">
+      <div class="cards">
+        <div class="card">
+          <h3>Disclaimers</h3>
+          <p>This site is informational only and not an offer to sell securities. Investors self-attest accreditation and acknowledge jurisdictional limits.</p>
+          <p>We do not process funds or custody. Allocations are non-binding until you complete full diligence and definitive docs with the issuer.</p>
+        </div>
+        <div class="card">
+          <h3>Ops & reporting</h3>
+          <ul class="checks">
+            <li>Airtable workspace for leads, allocation requests, and intake status.</li>
+            <li>MailerLite list for updates and drop announcements.</li>
+            <li>Monthly portfolio email with reported repayments and coverage.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Contact</h3>
+          <p>Email <a href="mailto:invest@atlasyield.xyz">invest@atlasyield.xyz</a> or book a slot.</p>
+          <a class="button ghost" href="https://calendly.com" target="_blank" rel="noreferrer">Open Calendly</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div class="modal" id="deal-modal" aria-hidden="true">
+    <div class="modal-backdrop" data-close></div>
+    <div class="modal-card" role="dialog" aria-modal="true">
+      <button class="close" data-close aria-label="Close">×</button>
+      <div id="modal-content"></div>
+    </div>
+  </div>
+
+  <script src="assets/data.js"></script>
+  <script src="assets/scripts.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static HTML/CSS/JS starter for the RWA marketplace with filters, modal detail view, and intake form embeds
- include sample deal data, analytics snippet slot, and macOS-friendly quickstart instructions
- document repo location of the starter inside the existing MVP plan

## Testing
- Not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da59c31c0832c8025ebd3cbbf2a6b)